### PR TITLE
Add support for `eslint-plugin-ember`

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -2,6 +2,7 @@
   "angular": "https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/RULENAME.md",
   "ava": "https://github.com/avajs/eslint-plugin-ava/blob/master/docs/rules/RULENAME.md",
   "backbone": "https://github.com/ilyavolodin/eslint-plugin-backbone/blob/master/docs/rules/RULENAME.md",
+  "ember": "https://github.com/netguru/eslint-plugin-ember/blob/master/docs/rules/RULENAME.md",
   "flowtype": "https://github.com/gajus/eslint-plugin-flowtype#RULENAME",
   "fp": "https://github.com/jfmengels/eslint-plugin-fp/blob/master/docs/rules/RULENAME.md",
   "immutable": "https://github.com/jhusain/eslint-plugin-immutable#RULENAME",


### PR DESCRIPTION
`eslint-plugin-netguru-ember` has [been deprecated](https://github.com/netguru/eslint-plugin-netguru-ember#️️️-deprecation-warning-️️️) and superseded by `eslint-plugin-ember`. This PR does not remove `eslint-plugin-netguru-ember`, as some may still be using it in their projects.