### PR TITLE
Throw if ruleId is not a string

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,10 @@
 var plugins = require('./plugins.json');
 
 function getRuleURI(ruleId) {
+  if (typeof ruleId !== 'string') {
+    throw new TypeError(`ruleId must be a string, got ${typeof ruleId}`);
+  }
+
   var ruleParts = ruleId.split('/');
 
   if (ruleParts.length === 1) {

--- a/test.js
+++ b/test.js
@@ -81,3 +81,7 @@ test('should return url to help improve this tool', t => {
       url: 'https://github.com/jfmengels/eslint-rule-documentation/blob/master/contributing.md'
     });
 });
+
+test('should throw when ruleId is not a string', t => {
+  t.throws(() => getRuleURI(null), 'ruleId must be a string, got object');
+});


### PR DESCRIPTION
This makes it more obvious where and why the error occurred.

Before:

```
TypeError: Cannot read property 'split' of null
```

After:

```
TypeError: ruleId must be a string, got object
```