### PR TITLE
Stop testing on Node.js v0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: node_js
 node_js:
   - '6'
   - '4'
-  - '0.12'


### PR DESCRIPTION
The minimum Node.js version specified in package.json is listed as v4.0.0, and as v0.12.x hasn't been supported by Node.js for almost a year now there isn't any point in keeping it in the test matrix.

Any objections @jfmengels? Note that this _isn't_ a breaking change!