### PR TITLE
Use HTTPS for eslint.org links

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function getRuleURI(ruleId) {
   if (ruleParts.length === 1) {
     return {
       found: true,
-      url: 'http://eslint.org/docs/rules/' + ruleId
+      url: 'https://eslint.org/docs/rules/' + ruleId
     };
   }
 

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ const getRuleURI = require('eslint-rule-documentation');
 
 // find url for core rules
 getRuleURI('no-var');
-// => { found: true, url: 'http://eslint.org/docs/rules/no-var' }
+// => { found: true, url: 'https://eslint.org/docs/rules/no-var' }
 
 // find url for known plugins
 getRuleURI('import/no-unresolved');
@@ -73,5 +73,5 @@ Special thanks to the team behind [linter-eslint] for the original work, and the
 MIT © [Jeroen Engels](https://github.com/jfmengels)
 
 [eslint-plugin-import]: https://github.com/benmosher/eslint-plugin-import
-[ESLint]: http://eslint.org/
+[ESLint]: https://eslint.org/
 [linter-eslint]: https://github.com/AtomLinter/linter-eslint

--- a/test.js
+++ b/test.js
@@ -6,17 +6,17 @@ test('should return url of core rules', t => {
   t.deepEqual(getRuleURI('no-var'),
     {
       found: true,
-      url: 'http://eslint.org/docs/rules/no-var'
+      url: 'https://eslint.org/docs/rules/no-var'
     });
   t.deepEqual(getRuleURI('no-console'),
     {
       found: true,
-      url: 'http://eslint.org/docs/rules/no-console'
+      url: 'https://eslint.org/docs/rules/no-console'
     });
   t.deepEqual(getRuleURI('array-callback-return'),
     {
       found: true,
-      url: 'http://eslint.org/docs/rules/array-callback-return'
+      url: 'https://eslint.org/docs/rules/array-callback-return'
     });
 });
 


### PR DESCRIPTION
[eslint.org now supports HTTPS](https://twitter.com/geteslint/status/898373493720469504):

> eslint.org  is now served over HTTPS! Please let us know if you encounter any issues.