### PR TITLE
Update eslint-plugin-angular

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1,5 +1,5 @@
 {
-  "angular": "https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/RULENAME.md",
+  "angular": "Gillespie59",
   "ava": "avajs",
   "backbone": "ilyavolodin",
   "ember": "netguru",


### PR DESCRIPTION
I updated the plugin to move the docs to `docs/rules`: Gillespie59/eslint-plugin-angular#496