### PR TITLE
Remove eslint-plugin-promise from plugins.json

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -27,7 +27,6 @@
   "no-use-extend-native": "dustinspecker",
   "node": "mysticatea",
   "prettier": "https://github.com/prettier/eslint-plugin-prettier#options",
-  "promise": "https://github.com/xjamundx/eslint-plugin-promise#RULENAME",
   "protractor": "alecxe",
   "react": "yannickcr",
   "react-native": "Intellicode",

--- a/test.js
+++ b/test.js
@@ -47,16 +47,6 @@ test('should return url of found plugin rules', t => {
       found: true,
       url: 'https://github.com/mysticatea/eslint-plugin-eslint-comments/blob/master/docs/rules/no-unlimited-disable.md'
     });
-  t.deepEqual(getRuleURI('promise/no-native'),
-    {
-      found: true,
-      url: 'https://github.com/xjamundx/eslint-plugin-promise#no-native'
-    });
-  t.deepEqual(getRuleURI('promise/catch-or-return'),
-    {
-      found: true,
-      url: 'https://github.com/xjamundx/eslint-plugin-promise#catch-or-return'
-    });
   t.deepEqual(getRuleURI('standard/array-bracket-even-spacing'),
     {
       found: true,


### PR DESCRIPTION
https://github.com/xjamundx/eslint-plugin-promise/pull/91 was just merged, which introduces `meta.docs.url` for all `eslint-plugin-promise` rules.