### PR TITLE
Fix eslint-plugin-promise docs location

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -27,7 +27,7 @@
   "no-use-extend-native": "dustinspecker",
   "node": "mysticatea",
   "prettier": "https://github.com/prettier/eslint-plugin-prettier#options",
-  "promise": "https://github.com/xjamundx/eslint-plugin-promise#RULENAME",
+  "promise": "xjamundx",
   "protractor": "alecxe",
   "react": "yannickcr",
   "react-native": "Intellicode",

--- a/test.js
+++ b/test.js
@@ -50,12 +50,12 @@ test('should return url of found plugin rules', t => {
   t.deepEqual(getRuleURI('promise/no-native'),
     {
       found: true,
-      url: 'https://github.com/xjamundx/eslint-plugin-promise#no-native'
+      url: 'https://github.com/xjamundx/eslint-plugin-promise/blob/master/docs/rules/no-native.md'
     });
   t.deepEqual(getRuleURI('promise/catch-or-return'),
     {
       found: true,
-      url: 'https://github.com/xjamundx/eslint-plugin-promise#catch-or-return'
+      url: 'https://github.com/xjamundx/eslint-plugin-promise/blob/master/docs/rules/catch-or-return.md'
     });
   t.deepEqual(getRuleURI('standard/array-bracket-even-spacing'),
     {


### PR DESCRIPTION
https://github.com/xjamundx/eslint-plugin-promise/pull/112 moves the eslint-plugin-promise documentation from the README to a `docs/rules` directory. These paths are properly annotated in the `meta.docs.url` property for each rule, but until the next version of eslint-plugin-promise is released, we'll need to direct users the new URL in this PR.