### PR TITLE
Add support for eslint-plugin-redux-saga

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -31,6 +31,7 @@
   "protractor": "alecxe",
   "react": "yannickcr",
   "react-native": "Intellicode",
+  "redux-saga": "pke",
   "requirejs": "cvisco",
   "standard": "https://github.com/xjamundx/eslint-plugin-standard#rules-explanations",
   "typescript": "nzakas",


### PR DESCRIPTION
## Description

This PR adds support for [eslint-plugin-redux-saga].

> **Note:** [eslint-plugin-redux-saga] supports the `https://github.com/USERNAME/eslint-plugin-PLUGINNAME/blob/master/docs/rules/RULENAME.md` convention.

Ex: [redux-saga/no-yield-in-race](https://github.com/pke/eslint-plugin-redux-saga/blob/master/docs/rules/no-yield-in-race.md).

## PR

- [x] Read contributing guidelines.
- [x] Added support for [eslint-plugin-redux-saga]
- [x] CCed plugin author

[eslint-plugin-redux-saga]: https://github.com/pke/eslint-plugin-redux-saga