### PR TITLE
Add support for @typescript-eslint

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1,4 +1,5 @@
 {
+  "@typescript-eslint": "https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/RULENAME.md",
   "angular": "Gillespie59",
   "ava": "avajs",
   "backbone": "ilyavolodin",

--- a/test.js
+++ b/test.js
@@ -62,6 +62,11 @@ test('should return url of found plugin rules', t => {
       found: true,
       url: 'https://github.com/xjamundx/eslint-plugin-standard#rules-explanations'
     });
+  t.deepEqual(getRuleURI('@typescript-eslint/array-type'),
+    {
+      found: true,
+      url: 'https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/array-type.md'
+    });
 });
 
 test.cb('should be able to parse `plugin.json`', t => {


### PR DESCRIPTION
This PR adds support for [@typescript-eslint](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin).