### PR TITLE
Adding support for You-Dont-Need-Lodash-Underscore

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -40,5 +40,6 @@
   "xo": "sindresorhus/eslint-plugin-unicorn",
   "visualforce": "forcedotcom",
   "vue": "vuejs",
-  "jsx-control-statements": "vkbansal"
+  "jsx-control-statements": "vkbansal",
+  "you-dont-need-lodash-underscore": "https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore/blob/master/README.md#RULENAME"
 }


### PR DESCRIPTION
I have added in the documentation URL for You-Dont-Need-Lodash-Underscore into
plugins.json. All tests still pass using the npx ava command.

URL to ESLint Plugin: https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore