### PR TITLE
Update Mozilla's ESLint docs to new location.

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -21,7 +21,7 @@
   "meteor": "dferber90",
   "mocha": "lo1tuma",
   "mongodb": "https://github.com/nfroidure/eslint-plugin-mongodb#RULENAME",
-  "mozilla": "https://gecko.readthedocs.io/en/latest/tools/lint/linters/eslint-plugin-mozilla.html#RULENAME",
+  "mozilla": "https://firefox-source-docs.mozilla.org/code-quality/lint/linters/eslint-plugin-mozilla/RULENAME.html",
   "netguru-ember": "https://github.com/netguru/eslint-plugin-netguru-ember/blob/master/docs/RULES.md#RULENAME",
   "no-unsanitized": "mozilla",
   "no-use-extend-native": "dustinspecker",


### PR DESCRIPTION
Mozilla's documentation has moved, so we would like to update the location to go with it. We're currently working on splitting out the rules per-page, so I've included the new format here and hopefully we'll complete that soon.