### PR TITLE
add support cypress, @typescript-eslint, @babel

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1,7 +1,6 @@
 {
   "angular": "Gillespie59",
   "ava": "avajs",
-  "@babel": "https://github.com/babel/babel/tree/main/eslint/babel-eslint-plugin/test/rules/RULENAME.md",
   "backbone": "ilyavolodin",
   "cypress": "cypress-io",
   "ember": "netguru",

--- a/plugins.json
+++ b/plugins.json
@@ -1,7 +1,10 @@
 {
   "angular": "Gillespie59",
   "ava": "avajs",
+  "@babel": "https://github.com/babel/babel/tree/main/eslint/babel-eslint-plugin/test/rules/RULENAME.md",
+  "@typescript-eslint": "https://github.com/typescript-eslint/typescript-eslint/tree/main/packages/eslint-plugin/docs/rules/RULENAME.md"
   "backbone": "ilyavolodin",
+  "cypress": "cypress-io"
   "ember": "netguru",
   "es6-recommended": "https://github.com/mgtitimoli/eslint-plugin-es6-recommended#rules",
   "eslint-comments": "mysticatea",

--- a/plugins.json
+++ b/plugins.json
@@ -2,9 +2,8 @@
   "angular": "Gillespie59",
   "ava": "avajs",
   "@babel": "https://github.com/babel/babel/tree/main/eslint/babel-eslint-plugin/test/rules/RULENAME.md",
-  "@typescript-eslint": "https://github.com/typescript-eslint/typescript-eslint/tree/main/packages/eslint-plugin/docs/rules/RULENAME.md"
   "backbone": "ilyavolodin",
-  "cypress": "cypress-io"
+  "cypress": "cypress-io",
   "ember": "netguru",
   "es6-recommended": "https://github.com/mgtitimoli/eslint-plugin-es6-recommended#rules",
   "eslint-comments": "mysticatea",
@@ -38,6 +37,7 @@
   "requirejs": "cvisco",
   "security": "https://github.com/nodesecurity/eslint-plugin-security#rules",
   "standard": "https://github.com/xjamundx/eslint-plugin-standard#rules-explanations",
+  "@typescript-eslint": "https://github.com/typescript-eslint/typescript-eslint/tree/main/packages/eslint-plugin/docs/rules/RULENAME.md",
   "typescript": "nzakas",
   "unicorn": "sindresorhus",
   "xo": "sindresorhus/eslint-plugin-unicorn",


### PR DESCRIPTION
Added [cypress](https://github.com/cypress-io/eslint-plugin-cypress) and @[typescript](https://github.com/typescript-eslint/typescript-eslint) support (babel removed)